### PR TITLE
fix: baseUrl error for github pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: 'Feature Probe',
   tagline: 'An open source feature management service',
   url: 'https://featureprobe.github.io',
-  baseUrl: '/feature-probe-docs',
+  baseUrl: '/feature-probe-docs/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: 'Feature Probe',
   tagline: 'An open source feature management service',
   url: 'https://featureprobe.github.io',
-  baseUrl: '/',
+  baseUrl: '/feature-probe-docs',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
<img width="1624" alt="Screen Shot 2022-08-23 at 21 47 15" src="https://user-images.githubusercontent.com/49837965/186174851-9baa9170-c1b7-4c0a-ba24-c1a4688bee6d.png">
